### PR TITLE
Add database connection exception hierarchy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,27 @@
+name: Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php: '5.5'
+            composer: 'v2.2'
+          - php: '8.5'
+            composer: 'latest'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: composer:${{ matrix.composer }}
+          coverage: none
+      - run: composer update --prefer-dist --no-interaction
+      - run: vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -49,6 +49,27 @@ Note that the connection name passed to the `getConnection` method matches
 what is defined in the `.env` file. You can therefore change this argument in
 order to manage and connect to multiple databases easily.
 
+## Exceptions
+
+All package exceptions extend `JordJD\DCOM\Exceptions\DCOMException`, so callers
+can catch the base class or handle a specific condition:
+
+- `MissingEnvironmentVariableException`
+- `InvalidObjectTypeException`
+- `UnsupportedDatabaseTypeException`
+- `DriverUnavailableException`
+- `ConnectionException`
+
+```php
+use JordJD\DCOM\Exceptions\ConnectionException;
+
+try {
+    $connection = DCOM::getConnection('main');
+} catch (ConnectionException $exception) {
+    // Handle a failed database connection.
+}
+```
+
 ## Example
 
 For an actual example of how to use PHP DCOM, see the [`test` directory](test/).

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,18 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "3.0-dev"
+      "dev-master": "3.x-dev"
     }
   },
-  "require-dev": {}
+  "require-dev": {
+    "phpunit/phpunit": "^4.8 || ^9.6 || ^12.0"
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "JordJD\\DCOM\\Tests\\": "tests/"
+    }
+  },
+  "scripts": {
+    "test": "phpunit"
+  }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="PHP DCOM">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/DCOM.php
+++ b/src/DCOM.php
@@ -2,8 +2,11 @@
 
 namespace JordJD\DCOM;
 
-use Exception;
-
+use JordJD\DCOM\Exceptions\ConnectionException;
+use JordJD\DCOM\Exceptions\DriverUnavailableException;
+use JordJD\DCOM\Exceptions\InvalidObjectTypeException;
+use JordJD\DCOM\Exceptions\MissingEnvironmentVariableException;
+use JordJD\DCOM\Exceptions\UnsupportedDatabaseTypeException;
 use mysqli;
 use PDO;
 
@@ -21,73 +24,81 @@ abstract class DCOM
         $objType = self::getEnvVar($name, 'object_type');
         $dbType = self::getEnvVar($name, 'database_type');
 
-        switch($objType) {
+        switch ($objType) {
 
             case 'mysqli':
 
-                if ($dbType!='mysql') {
-                    throw new Exception('Mysqli objects only support MySQL databases. Change your database type to \'mysql\'.');
+                if ($dbType != 'mysql') {
+                    throw new UnsupportedDatabaseTypeException('Mysqli objects only support MySQL databases. Change your database type to \'mysql\'.');
+                }
+
+                if (!class_exists('mysqli')) {
+                    throw new DriverUnavailableException('The mysqli extension is not available on this server.');
                 }
 
                 $dbHost = self::getEnvVar($name, 'database_host');
                 $dbUsername = self::getEnvVar($name, 'database_username');
-                $dbPassword = self::getEnvVar($name, 'database_password');
+                $dbPassword = self::getEnvVar($name, 'database_password', true);
                 $dbName = self::getEnvVar($name, 'database_name');
 
-                $mysqli = new mysqli($dbHost, $dbUsername, $dbPassword, $dbName);
+                try {
+                    $mysqli = new mysqli($dbHost, $dbUsername, $dbPassword, $dbName);
+                } catch (\Exception $e) {
+                    throw new ConnectionException('Failed to connect to MySQL: '.$e->getMessage(), 0, $e);
+                }
 
                 if ($mysqli->connect_errno) {
-                    throw new Exception("Failed to connect to MySQL: (".$mysqli->connect_errno.") ".$mysqli->connect_error);
+                    throw new ConnectionException("Failed to connect to MySQL: (".$mysqli->connect_errno.") ".$mysqli->connect_error, $mysqli->connect_errno);
                 }
 
                 self::$connections[$name] = $mysqli;
 
                 return $mysqli;
 
-                break;
-
             case 'pdo':
+
+                if (!class_exists('PDO')) {
+                    throw new DriverUnavailableException('The PDO extension is not available on this server.');
+                }
 
                 $availableDrivers = PDO::getAvailableDrivers();
 
                 if (!in_array($dbType, $availableDrivers)) {
-                    throw new Exception('PDO on this server does not support the requested database type. Change your database type to one the following: '.implode(', ', $availableDrivers));
+                    throw new UnsupportedDatabaseTypeException('PDO on this server does not support the requested database type. Change your database type to one of the following: '.implode(', ', $availableDrivers));
                 }
 
                 $dbHost = self::getEnvVar($name, 'database_host');
                 $dbUsername = self::getEnvVar($name, 'database_username');
-                $dbPassword = self::getEnvVar($name, 'database_password');
+                $dbPassword = self::getEnvVar($name, 'database_password', true);
                 $dbName = self::getEnvVar($name, 'database_name');
 
                 $dsn = $dbType.':dbname='.$dbName.';host='.$dbHost;
 
                 try {
                     $pdo = new PDO($dsn, $dbUsername, $dbPassword);
-                } catch (PDOException $e) {
-                    echo 'Failed to connect to database (via PDO): ' . $e->getMessage();
+                } catch (\PDOException $e) {
+                    throw new ConnectionException('Failed to connect to database via PDO: '.$e->getMessage(), 0, $e);
                 }
 
                 self::$connections[$name] = $pdo;
 
                 return $pdo;
 
-                break;
-
             default:
 
-                throw new Exception('Unexpected object type: \''.$objType.'\'.');
+                throw new InvalidObjectTypeException('Unexpected object type: \''.$objType.'\'.');
 
         }
     }
 
-    private static function getEnvVar($name, $key)
+    private static function getEnvVar($name, $key, $allowEmpty = false)
     {
         $varName = strtoupper(self::$envPrefix.'_'.$name.'_'.$key);
 
         $value = getenv($varName);
 
-        if (!$value) {
-            throw new Exception('Empty or non-existant environment variable: \''.$varName.'\'. Please ensure it exists in your `.env` file.');
+        if ($value === false || (!$allowEmpty && $value === '')) {
+            throw new MissingEnvironmentVariableException('Missing or empty environment variable: \''.$varName.'\'. Please ensure it exists in your `.env` file.');
         }
 
         return $value;

--- a/src/Exceptions/ConnectionException.php
+++ b/src/Exceptions/ConnectionException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace JordJD\DCOM\Exceptions;
+
+class ConnectionException extends DCOMException
+{
+}

--- a/src/Exceptions/DCOMException.php
+++ b/src/Exceptions/DCOMException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace JordJD\DCOM\Exceptions;
+
+class DCOMException extends \Exception
+{
+}

--- a/src/Exceptions/DriverUnavailableException.php
+++ b/src/Exceptions/DriverUnavailableException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace JordJD\DCOM\Exceptions;
+
+class DriverUnavailableException extends DCOMException
+{
+}

--- a/src/Exceptions/InvalidObjectTypeException.php
+++ b/src/Exceptions/InvalidObjectTypeException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace JordJD\DCOM\Exceptions;
+
+class InvalidObjectTypeException extends DCOMException
+{
+}

--- a/src/Exceptions/MissingEnvironmentVariableException.php
+++ b/src/Exceptions/MissingEnvironmentVariableException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace JordJD\DCOM\Exceptions;
+
+class MissingEnvironmentVariableException extends DCOMException
+{
+}

--- a/src/Exceptions/UnsupportedDatabaseTypeException.php
+++ b/src/Exceptions/UnsupportedDatabaseTypeException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace JordJD\DCOM\Exceptions;
+
+class UnsupportedDatabaseTypeException extends DCOMException
+{
+}

--- a/tests/DCOMTest.php
+++ b/tests/DCOMTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace JordJD\DCOM\Tests;
+
+use JordJD\DCOM\DCOM;
+use JordJD\DCOM\Exceptions\InvalidObjectTypeException;
+use JordJD\DCOM\Exceptions\MissingEnvironmentVariableException;
+use JordJD\DCOM\Exceptions\UnsupportedDatabaseTypeException;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+class DCOMTest extends TestCase
+{
+    public function testMissingEnvironmentVariableHasSpecificException()
+    {
+        putenv('DCOM_MISSING_OBJECT_TYPE');
+
+        try {
+            DCOM::getConnection('missing');
+            $this->fail('Expected a missing environment variable exception.');
+        } catch (MissingEnvironmentVariableException $e) {
+            $this->assertNotFalse(strpos($e->getMessage(), 'DCOM_MISSING_OBJECT_TYPE'));
+        }
+    }
+
+    public function testInvalidObjectTypeHasSpecificException()
+    {
+        putenv('DCOM_INVALID_OBJECT_TYPE=odbc');
+        putenv('DCOM_INVALID_DATABASE_TYPE=mysql');
+
+        try {
+            DCOM::getConnection('invalid');
+            $this->fail('Expected an invalid object type exception.');
+        } catch (InvalidObjectTypeException $e) {
+            $this->assertNotFalse(strpos($e->getMessage(), 'odbc'));
+        }
+    }
+
+    public function testUnsupportedMysqliDatabaseTypeHasSpecificException()
+    {
+        putenv('DCOM_UNSUPPORTED_OBJECT_TYPE=mysqli');
+        putenv('DCOM_UNSUPPORTED_DATABASE_TYPE=pgsql');
+
+        try {
+            DCOM::getConnection('unsupported');
+            $this->fail('Expected an unsupported database type exception.');
+        } catch (UnsupportedDatabaseTypeException $e) {
+            $this->assertNotFalse(strpos($e->getMessage(), 'MySQL'));
+        }
+    }
+
+    public function testEmptyDatabasePasswordsAreAllowed()
+    {
+        putenv('DCOM_EMPTY_DATABASE_PASSWORD=');
+
+        $method = new ReflectionMethod(DCOM::class, 'getEnvVar');
+        $method->setAccessible(true);
+
+        $this->assertSame('', $method->invoke(null, 'empty', 'database_password', true));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,7 @@
+<?php
+
+require dirname(__DIR__).'/vendor/autoload.php';
+
+if (!class_exists('PHPUnit\\Framework\\TestCase') && class_exists('PHPUnit_Framework_TestCase')) {
+    class_alias('PHPUnit_Framework_TestCase', 'PHPUnit\\Framework\\TestCase');
+}


### PR DESCRIPTION
- Add specific exceptions under a shared DCOMException base class.
- Convert PDO failures from printed messages and undefined returns into ConnectionException instances with the original exception attached.
- Detect unavailable mysqli/PDO drivers explicitly.
- Allow intentionally empty database passwords while still rejecting missing required environment variables.
- Add PHP 5.5 and PHP 8.5 regression tests without raising the minimum PHP version.

Closes #1.